### PR TITLE
 fix for "etcd: discovery: size key not found" error

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -279,8 +279,12 @@ func TestExampleObjectSchemas(t *testing.T) {
 			"pod": &api.Pod{},
 		},
 		"../examples/openshift-origin": {
-			"openshift-controller": &api.ReplicationController{},
-			"openshift-service":    &api.Service{},
+			"openshift-controller":      &api.ReplicationController{},
+			"openshift-service":         &api.Service{},
+			"etcd-controller":           &api.ReplicationController{},
+			"etcd-service":              &api.Service{},
+			"etcd-discovery-controller": &api.ReplicationController{},
+			"etcd-discovery-service":    &api.Service{},
 		},
 		"../examples/phabricator": {
 			"authenticator-controller": &api.ReplicationController{},

--- a/examples/openshift-origin/cleanup.sh
+++ b/examples/openshift-origin/cleanup.sh
@@ -15,11 +15,30 @@
 # limitations under the License.
 
 # Cleans up resources from the example, assumed to be run from Kubernetes repo root
-
+echo
+echo
 export OPENSHIFT_EXAMPLE=$(pwd)/examples/openshift-origin
 export OPENSHIFT_CONFIG=${OPENSHIFT_EXAMPLE}/config
-rm -fr ${OPENSHIFT_CONFIG}
-cluster/kubectl.sh delete secrets openshift-config
-cluster/kubectl.sh stop rc openshift
-cluster/kubectl.sh delete rc openshift
-cluster/kubectl.sh delete services openshift
+
+echo "===> Removing OpenShift:"
+kubectl delete secrets openshift-config
+kubectl delete rc openshift
+kubectl delete services openshift
+echo
+
+echo "===> Removing etcd:"
+kubectl delete rc etcd
+kubectl delete services etcd
+echo
+
+echo "===> Removing etcd-discovery:"
+kubectl delete rc etcd-discovery
+kubectl delete services etcd-discovery
+echo
+
+echo "===> Removing local files:"
+rm -rf ${OPENSHIFT_CONFIG}
+rm ${OPENSHIFT_EXAMPLE}/secret.json
+echo
+
+echo Done.

--- a/examples/openshift-origin/etcd-controller.yaml
+++ b/examples/openshift-origin/etcd-controller.yaml
@@ -33,6 +33,10 @@ spec:
           value: new
         - name: ETCD_INITIAL_CLUSTER_TOKEN
           value: etcd-cluster-hd84j
+        - name: ETCD_DISCOVERY_URL
+          value: http://etcd-discovery:2379
+        - name: ETCD_DISCOVERY_TOKEN
+          value: upay9zdbi9wy9y6bkfokn0w4n506c9gb9880qbvr
         - name: ETCD_DISCOVERY
           value: http://etcd-discovery:2379/v2/keys/discovery/upay9zdbi9wy9y6bkfokn0w4n506c9gb9880qbvr
         resources: {}

--- a/examples/openshift-origin/etcd-controller.yaml
+++ b/examples/openshift-origin/etcd-controller.yaml
@@ -1,0 +1,48 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: etcd
+  creationTimestamp: 
+spec:
+  strategy:
+    type: Recreate
+    resources: {}
+  triggers:
+  - type: ConfigChange
+  replicas: 3
+  selector:
+    name: etcd
+  template:
+    metadata:
+      creationTimestamp: 
+      labels:
+        name: etcd
+    spec:
+      containers:
+      - name: member
+        image: openshift/etcd-20-centos7
+        ports:
+        - containerPort: 2379
+          protocol: TCP
+        - containerPort: 2380
+          protocol: TCP
+        env:
+        - name: ETCD_NUM_MEMBERS
+          value: '3'
+        - name: ETCD_INITIAL_CLUSTER_STATE
+          value: new
+        - name: ETCD_INITIAL_CLUSTER_TOKEN
+          value: etcd-cluster-hd84j
+        - name: ETCD_DISCOVERY
+          value: http://etcd-discovery:2379/v2/keys/discovery/upay9zdbi9wy9y6bkfokn0w4n506c9gb9880qbvr
+        resources: {}
+        terminationMessagePath: "/dev/termination-log"
+        imagePullPolicy: IfNotPresent
+        capabilities: {}
+        securityContext:
+          capabilities: {}
+          privileged: false
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      serviceAccount: ''
+status: {}

--- a/examples/openshift-origin/etcd-discovery-controller.yaml
+++ b/examples/openshift-origin/etcd-discovery-controller.yaml
@@ -1,0 +1,39 @@
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: etcd-discovery
+  creationTimestamp: 
+spec:
+  strategy:
+    type: Recreate
+    resources: {}
+  triggers:
+  - type: ConfigChange
+  replicas: 1
+  selector:
+    name: etcd-discovery
+  template:
+    metadata:
+      creationTimestamp: 
+      labels:
+        name: etcd-discovery
+    spec:
+      containers:
+      - name: discovery
+        image: openshift/etcd-20-centos7
+        args:
+        - etcd-discovery.sh
+        ports:
+        - containerPort: 2379
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: "/dev/termination-log"
+        imagePullPolicy: IfNotPresent
+        capabilities: {}
+        securityContext:
+          capabilities: {}
+          privileged: false
+      restartPolicy: Always
+      dnsPolicy: ClusterFirst
+      serviceAccount: ''
+status: {}

--- a/examples/openshift-origin/etcd-discovery-service.yaml
+++ b/examples/openshift-origin/etcd-discovery-service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: etcd-discovery
+  creationTimestamp: 
+  labels:
+    name: etcd-discovery
+spec:
+  ports:
+  - protocol: TCP
+    port: 2379
+    targetPort: 2379
+    nodePort: 0
+  selector:
+    name: etcd-discovery
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/examples/openshift-origin/etcd-service.yaml
+++ b/examples/openshift-origin/etcd-service.yaml
@@ -1,0 +1,25 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: etcd
+  creationTimestamp: 
+  labels:
+    name: etcd
+spec:
+  ports:
+  - name: client
+    protocol: TCP
+    port: 2379
+    targetPort: 2379
+    nodePort: 0
+  - name: server
+    protocol: TCP
+    port: 2380
+    targetPort: 2380
+    nodePort: 0
+  selector:
+    name: etcd
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/examples/openshift-origin/openshift-service.yaml
+++ b/examples/openshift-origin/openshift-service.yaml
@@ -4,8 +4,8 @@ metadata:
   name: openshift
 spec:
   ports:
-    - port: 8443
-      name: openshift
+    - name: openshift
+      port: 8443
       targetPort: 8443
   selector:
     name: openshift

--- a/tmp-valid-pod.json
+++ b/tmp-valid-pod.json
@@ -1,0 +1,36 @@
+{
+    "kind": "Pod",
+    "apiVersion": "v1",
+    "metadata": {
+        "name": "valid-pod",
+        "namespace": "default",
+        "selfLink": "/api/v1/namespaces/default/pods/valid-pod",
+        "uid": "20f4f1f5-1e67-11e5-b84d-54ee753e2644",
+        "resourceVersion": "474",
+        "creationTimestamp": "2015-06-29T13:59:58Z",
+        "labels": {
+            "name": "valid-pod"
+        }
+    },
+    "spec": {
+        "containers": [
+            {
+                "name": "update-k8s-serve-hostname",
+                "image": "nginx",
+                "resources": {
+                    "limits": {
+                        "cpu": "1",
+                        "memory": "6Mi"
+                    }
+                },
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent"
+            }
+        ],
+        "restartPolicy": "Always",
+        "dnsPolicy": "ClusterFirst"
+    },
+    "status": {
+        "phase": "Pending"
+    }
+}


### PR DESCRIPTION
openshift/etcd-20-centos7 image has script: /usr/local/bin/etcd.sh
which requires two ENV variables to work: ETCD_DISCOVERY_URL and ETCD_DISCOVERY_TOKEN and it build resulting URL by itself, thus completely ignoring ETCD_DISCOVERY variable.
I've introduced these variables and etcd cluster got autodiscovered and worked.
